### PR TITLE
Exclude undistorted OpenSfM images from final uploads

### DIFF
--- a/app/s3/files.go
+++ b/app/s3/files.go
@@ -37,6 +37,26 @@ var imageIncludePatterns = []string{
 	"*.TAR",
 }
 
+var uploadExcludePatterns = []string{
+	".rclone/**",
+	"opensfm/undistorted/**",
+	"**/opensfm/undistorted/**",
+}
+
+func renderRcloneExcludeFlags(excludePatterns []string) string {
+	if len(excludePatterns) == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	for _, pattern := range excludePatterns {
+		b.WriteString(` --exclude "`)
+		b.WriteString(pattern)
+		b.WriteString(`"`)
+	}
+	return b.String()
+}
+
 // renderRcloneFilterFile builds the contents of a rclone --filter-from file.
 // Order matters: excludes go first (so they win over the catch-all includes
 // below), then includes for image/archive extensions, then a final catch-all
@@ -265,6 +285,8 @@ find "$DEST_DIR" -type f \( -iname "*.jpg" -o -iname "*.jpeg" -o -iname "*.tiff"
 // Credentials are injected via Kubernetes Secret references in the workflow spec
 // Note: We create rclone config on-the-fly to avoid ContainerSet env var filtering of RCLONE_CONFIG_*
 func GenerateUploadScript(destPath string) string {
+	uploadExcludeFlags := renderRcloneExcludeFlags(uploadExcludePatterns)
+
 	return `set -e
 set -o pipefail
 echo "Running final upload..."
@@ -337,7 +359,7 @@ echo "Listing ODM imagery products..."
 ls -lh "$SRC_DIR"
 
 echo "Uploading to S3..."
-if ! rclone copy "$SRC_DIR" "$S3_REMOTE" --exclude ".rclone/**" --progress; then
+if ! rclone copy "$SRC_DIR" "$S3_REMOTE"` + uploadExcludeFlags + ` --progress; then
   echo "Upload failed."
   exit 1
 fi

--- a/app/s3/s3_test.go
+++ b/app/s3/s3_test.go
@@ -237,6 +237,15 @@ func TestGenerateUploadScript_TestWriteFailureSurvivesErrexit(t *testing.T) {
 	assert.NotContains(t, script, "TEST_OUTPUT=$(rclone copyto \"$TEST_FILE\" \"$TEST_OBJECT\" 2>&1)\nTEST_EXIT_CODE=$?")
 }
 
+func TestGenerateUploadScript_ExcludesUndistortedOpenSfMImages(t *testing.T) {
+	script := GenerateUploadScript("s3://bucket/output/")
+
+	assert.Contains(t, script, `--exclude ".rclone/**"`)
+	assert.Contains(t, script, `--exclude "opensfm/undistorted/**"`)
+	assert.Contains(t, script, `--exclude "**/opensfm/undistorted/**"`)
+	assert.Contains(t, script, `rclone copy "$SRC_DIR" "$S3_REMOTE"`)
+}
+
 func TestRenderRcloneFilterFile_OrderingAndFormat(t *testing.T) {
 	out := renderRcloneFilterFile([]string{"odm_orthophoto/**", "all.zip"})
 


### PR DESCRIPTION
## Summary
- Exclude OpenSfM `opensfm/undistorted` raw image copies from the final rclone upload.
- Keep the existing `.rclone/**` upload exclusion while applying the new upload excludes from one generated flag list.
- Add coverage for the generated upload script so the exclusions remain in place.

## Context
ScaleODM already removes the input `images` directory before uploading final ODM results, but OpenSfM can leave duplicated raw image copies under `opensfm/undistorted`. Those files are needed during processing, but they do not need to be uploaded as final output artifacts.

This PR applies the exclusion only at the final upload step, so the processing workspace remains unchanged while S3 storage usage is reduced.

## Testing
- `git diff --check`
- `docker run --rm -v "$PWD":/src -w /src golang:1.26 go test ./app/s3 -run "TestGenerateUploadScript|TestRenderRcloneFilterFile"`
- `docker run --rm -v "$PWD":/src -w /src golang:1.26 go test ./app/workflows -run "TestBuildODMWorkflow|TestNewDefaultODMConfig"`
- `docker run --rm -v "$PWD":/src -w /src golang:1.26 go test ./... -run "^$"`
- `docker compose -f compose.yaml -f compose.test.yaml run --rm api`
- Verified the generated rclone exclude patterns against a local rclone copy fixture, confirming both root-level and nested `opensfm/undistorted` directories are skipped while other output products are copied.

Closes #10.

*This PR was developed by Codex with supervision from jmtdev0.*
